### PR TITLE
Refresh landing page for BURN app

### DIFF
--- a/assets/app-store-badge.svg
+++ b/assets/app-store-badge.svg
@@ -1,0 +1,7 @@
+<svg width="180" height="56" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="56" rx="12" fill="#0B1323"/>
+  <rect x="16" y="12" width="32" height="32" rx="8" fill="#111C30" stroke="#FF8C00" stroke-width="2"/>
+  <path d="M32 20C28 24 27 27 27 29C27 33 30 35.5 32 40C34 35.5 37 33 37 29C37 27 36 24 32 20Z" fill="#FF8C00"/>
+  <text x="56" y="24" fill="#F8FAFC" font-family="'SF Pro Display', 'Segoe UI', sans-serif" font-size="10" letter-spacing="0.12em">Download on the</text>
+  <text x="56" y="42" fill="#F8FAFC" font-family="'SF Pro Display', 'Segoe UI', sans-serif" font-size="18" font-weight="600">App Store</text>
+</svg>

--- a/assets/burn-icon.svg
+++ b/assets/burn-icon.svg
@@ -1,0 +1,13 @@
+<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1024" height="1024" rx="240" fill="#111C30"/>
+  <path d="M512 200C388 320 360 416 360 480C360 608 464 696 512 824C560 696 664 608 664 480C664 416 636 320 512 200Z" fill="url(#paint0_linear)"/>
+  <circle cx="512" cy="512" r="120" fill="white" fill-opacity="0.14"/>
+  <path d="M512 360L552 520H472L512 360Z" fill="white"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="360" y1="200" x2="704" y2="760" gradientUnits="userSpaceOnUse">
+      <stop offset="0.1" stop-color="#FFB347"/>
+      <stop offset="0.55" stop-color="#FF8C00"/>
+      <stop offset="1" stop-color="#FF5F00"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/assets/google-play-badge.svg
+++ b/assets/google-play-badge.svg
@@ -1,0 +1,9 @@
+<svg width="180" height="56" viewBox="0 0 180 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="56" rx="12" fill="#0B1323"/>
+  <path d="M18 16L34 28L18 40V16Z" fill="#34A853"/>
+  <path d="M34 28L46 18L18 16L34 28Z" fill="#4285F4"/>
+  <path d="M34 28L18 40L46 38L34 28Z" fill="#FBBC05"/>
+  <path d="M46 18L46 38L34 28L46 18Z" fill="#EA4335"/>
+  <text x="56" y="24" fill="#F8FAFC" font-family="'Roboto', 'Segoe UI', sans-serif" font-size="10" letter-spacing="0.12em">GET IT ON</text>
+  <text x="56" y="42" fill="#F8FAFC" font-family="'Roboto', 'Segoe UI', sans-serif" font-size="18" font-weight="600">Google Play</text>
+</svg>

--- a/assets/hero-screenshot.svg
+++ b/assets/hero-screenshot.svg
@@ -1,0 +1,15 @@
+<svg width="720" height="1280" viewBox="0 0 720 1280" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="720" height="1280" rx="56" fill="#111C30"/>
+  <rect x="60" y="120" width="600" height="120" rx="30" fill="#FF8C00" fill-opacity="0.15"/>
+  <rect x="120" y="172" width="360" height="16" rx="8" fill="#FF8C00" fill-opacity="0.5"/>
+  <rect x="60" y="300" width="600" height="280" rx="40" fill="#16253F"/>
+  <rect x="120" y="340" width="220" height="30" rx="15" fill="#FF8C00" fill-opacity="0.6"/>
+  <rect x="120" y="388" width="480" height="16" rx="8" fill="#1E3A8A"/>
+  <rect x="120" y="420" width="360" height="16" rx="8" fill="#1E3A8A" fill-opacity="0.7"/>
+  <rect x="60" y="620" width="600" height="280" rx="40" fill="#16253F"/>
+  <rect x="120" y="660" width="220" height="30" rx="15" fill="#FF8C00" fill-opacity="0.6"/>
+  <rect x="120" y="708" width="480" height="16" rx="8" fill="#1E3A8A"/>
+  <rect x="120" y="740" width="360" height="16" rx="8" fill="#1E3A8A" fill-opacity="0.7"/>
+  <rect x="240" y="980" width="240" height="72" rx="36" fill="#FF8C00"/>
+  <rect x="260" y="1006" width="200" height="20" rx="10" fill="white" fill-opacity="0.85"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,14 @@
   <title>BURN - 腕立て伏せカウンターアプリ</title>
   <meta name="description" content="近接センサーで自動カウント。腕立て伏せを記録して、毎日の成長を可視化しよう。">
   <style>
+    :root {
+      --color-background: #0f172a;
+      --color-surface: #111c30;
+      --color-accent: #ff8c00;
+      --color-text-primary: #f8fafc;
+      --color-text-secondary: #cbd5e1;
+    }
+
     * {
       margin: 0;
       padding: 0;
@@ -13,372 +21,333 @@
     }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      background: var(--color-background);
+      color: var(--color-text-primary);
       line-height: 1.6;
-      color: #fff;
-      background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 50%, #0f172a 100%);
+    }
+
+    img {
+      max-width: 100%;
+      display: block;
     }
 
     .container {
-      max-width: 1200px;
+      width: min(1120px, 90vw);
       margin: 0 auto;
-      padding: 0 20px;
     }
 
-    /* ヘッダー */
-    header {
-      padding: 20px 0;
-      position: fixed;
-      width: 100%;
-      top: 0;
-      z-index: 100;
-      background: rgba(15, 23, 42, 0.8);
-      backdrop-filter: blur(10px);
+    header.hero {
+      padding: 72px 0 64px;
+      background: linear-gradient(135deg, rgba(17, 28, 48, 0.75), rgba(15, 23, 42, 0.95));
     }
 
-    .header-content {
-      display: flex;
-      justify-content: space-between;
+    .hero-content {
+      display: grid;
+      gap: 48px;
       align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
 
-    .logo {
-      font-size: 32px;
-      font-weight: 900;
-      color: #ff8c00;
-      text-decoration: none;
-    }
-
-    nav a {
-      color: #fff;
-      text-decoration: none;
-      margin-left: 30px;
-      font-size: 14px;
-      transition: color 0.3s;
-    }
-
-    nav a:hover {
-      color: #ff8c00;
-    }
-
-    /* ヒーロー */
-    .hero {
-      padding: 150px 0 100px;
-      text-align: center;
+    .app-icon {
+      width: 112px;
+      height: 112px;
+      margin-bottom: 24px;
     }
 
     .hero h1 {
-      font-size: 72px;
+      font-size: clamp(3.5rem, 7vw, 4rem);
       font-weight: 900;
-      color: #ff8c00;
-      margin-bottom: 20px;
-      letter-spacing: -2px;
+      letter-spacing: -1px;
+      margin-bottom: 12px;
+      color: var(--color-text-primary);
     }
 
-    .hero .tagline {
-      font-size: 24px;
-      color: #ff8c00;
+    .tagline {
+      font-size: clamp(1.15rem, 3vw, 1.4rem);
       font-weight: 600;
-      letter-spacing: 2px;
-      margin-bottom: 30px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--color-accent);
+      margin-bottom: 20px;
     }
 
-    .hero p {
-      font-size: 18px;
-      color: #cbd5e1;
-      margin-bottom: 40px;
-      max-width: 600px;
-      margin-left: auto;
-      margin-right: auto;
+    .hero-description {
+      color: var(--color-text-secondary);
+      font-size: 1.05rem;
+      max-width: 480px;
+      margin-bottom: 36px;
     }
 
-    .cta-button {
-      display: inline-block;
-      background: linear-gradient(135deg, #ff8c00, #ff6b00);
-      color: #fff;
-      padding: 18px 50px;
-      border-radius: 50px;
-      text-decoration: none;
-      font-weight: 700;
-      font-size: 18px;
-      transition: transform 0.3s, box-shadow 0.3s;
-      box-shadow: 0 10px 30px rgba(255, 140, 0, 0.3);
+    .store-buttons {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
     }
 
-    .cta-button:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 15px 40px rgba(255, 140, 0, 0.4);
+    .store-buttons a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
 
-    /* 特徴セクション */
-    .features {
-      padding: 100px 0;
-      background: rgba(255, 255, 255, 0.03);
+    .store-buttons img {
+      height: 56px;
+      width: auto;
     }
 
-    .features h2 {
+    .hero-screenshot {
+      border-radius: 32px;
+      box-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+    }
+
+    section {
+      padding: 96px 0;
+    }
+
+    .section-heading {
       text-align: center;
-      font-size: 48px;
-      font-weight: 900;
-      margin-bottom: 60px;
+      font-size: clamp(2rem, 4vw, 2.5rem);
+      font-weight: 800;
+      margin-bottom: 16px;
+    }
+
+    .section-subtitle {
+      text-align: center;
+      color: var(--color-text-secondary);
+      max-width: 560px;
+      margin: 0 auto 56px;
+      font-size: 1rem;
     }
 
     .feature-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 40px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 32px;
     }
 
     .feature-card {
-      background: rgba(255, 255, 255, 0.05);
-      padding: 40px;
+      background: var(--color-surface);
       border-radius: 20px;
-      border: 1px solid rgba(255, 140, 0, 0.2);
-      backdrop-filter: blur(10px);
-      transition: transform 0.3s, border-color 0.3s;
-    }
-
-    .feature-card:hover {
-      transform: translateY(-5px);
-      border-color: rgba(255, 140, 0, 0.5);
+      padding: 32px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
     }
 
     .feature-icon {
-      font-size: 48px;
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      background: rgba(255, 140, 0, 0.12);
+      color: var(--color-accent);
+      display: grid;
+      place-items: center;
+      font-size: 1.8rem;
       margin-bottom: 20px;
     }
 
     .feature-card h3 {
-      font-size: 24px;
-      margin-bottom: 15px;
-      color: #ff8c00;
+      font-size: 1.2rem;
+      font-weight: 700;
+      margin-bottom: 12px;
     }
 
     .feature-card p {
-      color: #cbd5e1;
-      font-size: 16px;
-    }
-
-    /* 使い方セクション */
-    .how-it-works {
-      padding: 100px 0;
-    }
-
-    .how-it-works h2 {
-      text-align: center;
-      font-size: 48px;
-      font-weight: 900;
-      margin-bottom: 60px;
+      color: var(--color-text-secondary);
+      font-size: 0.95rem;
     }
 
     .steps {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 30px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 28px;
     }
 
-    .step {
+    .step-card {
+      background: var(--color-surface);
+      border-radius: 20px;
+      padding: 32px 28px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      display: grid;
+      gap: 16px;
+      justify-items: center;
       text-align: center;
-      padding: 30px;
     }
 
-    .step-number {
-      display: inline-block;
-      width: 60px;
-      height: 60px;
-      background: #ff8c00;
-      border-radius: 50%;
-      line-height: 60px;
-      font-size: 28px;
-      font-weight: 900;
-      margin-bottom: 20px;
+    .step-icon {
+      width: 72px;
+      height: 72px;
+      border-radius: 24px;
+      background: rgba(255, 140, 0, 0.15);
+      display: grid;
+      place-items: center;
+      font-size: 2rem;
+      color: var(--color-accent);
+      font-weight: 700;
     }
 
-    .step h3 {
-      font-size: 20px;
-      margin-bottom: 10px;
+    .step-card h3 {
+      font-size: 1.05rem;
+      font-weight: 700;
     }
 
-    .step p {
-      color: #cbd5e1;
-      font-size: 14px;
+    .step-card p {
+      color: var(--color-text-secondary);
+      font-size: 0.95rem;
     }
 
-    /* CTAセクション */
     .cta-section {
-      padding: 100px 0;
+      background: #141f35;
+      border-radius: 28px;
+      padding: 80px 40px;
       text-align: center;
-      background: rgba(255, 140, 0, 0.1);
     }
 
     .cta-section h2 {
-      font-size: 48px;
-      font-weight: 900;
-      margin-bottom: 30px;
+      font-size: clamp(2.2rem, 4vw, 2.8rem);
+      font-weight: 800;
+      margin-bottom: 16px;
     }
 
     .cta-section p {
-      font-size: 18px;
-      color: #cbd5e1;
-      margin-bottom: 40px;
+      color: var(--color-text-secondary);
+      margin-bottom: 32px;
+      font-size: 1rem;
     }
 
-    /* フッター */
     footer {
-      padding: 60px 0 30px;
-      background: rgba(0, 0, 0, 0.3);
-      text-align: center;
+      padding: 64px 0 48px;
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
     }
 
     .footer-links {
-      margin-bottom: 30px;
+      display: flex;
+      justify-content: center;
+      gap: 28px;
+      flex-wrap: wrap;
+      margin-bottom: 20px;
     }
 
     .footer-links a {
-      color: #cbd5e1;
+      color: var(--color-text-secondary);
       text-decoration: none;
-      margin: 0 20px;
-      font-size: 14px;
-      transition: color 0.3s;
+      font-size: 0.9rem;
+      transition: color 0.2s ease;
     }
 
     .footer-links a:hover {
-      color: #ff8c00;
+      color: var(--color-accent);
     }
 
     .copyright {
+      text-align: center;
       color: #64748b;
-      font-size: 14px;
+      font-size: 0.85rem;
     }
 
-    /* レスポンシブ */
-    @media (max-width: 768px) {
-      .hero h1 {
-        font-size: 48px;
+    @media (max-width: 640px) {
+      header.hero {
+        padding-top: 56px;
       }
 
-      .hero .tagline {
-        font-size: 18px;
+      .hero-description {
+        max-width: 100%;
       }
 
-      .features h2,
-      .how-it-works h2,
-      .cta-section h2 {
-        font-size: 36px;
-      }
-
-      nav {
-        display: none;
+      .store-buttons {
+        justify-content: center;
       }
     }
   </style>
 </head>
 <body>
-  <!-- ヘッダー -->
-  <header>
+  <header class="hero">
     <div class="container">
-      <div class="header-content">
-        <a href="#" class="logo">BURN</a>
-        <nav>
-          <a href="#features">特徴</a>
-          <a href="#how-it-works">使い方</a>
-          <a href="terms.html">利用規約</a>
-          <a href="privacy.html">プライバシーポリシー</a>
-        </nav>
+      <div class="hero-content">
+        <div>
+          <img src="assets/burn-icon.svg" alt="BURN アプリアイコン" class="app-icon">
+          <h1>BURN</h1>
+          <p class="tagline">Push-up Counter</p>
+          <p class="hero-description">近接センサーが自動でカウント。シンプルなUIで、毎日の腕立てを記録し、グラフで成長を振り返ることができます。</p>
+          <div class="store-buttons">
+            <a href="#"><img src="assets/app-store-badge.svg" alt="App Storeでダウンロード"></a>
+            <a href="#"><img src="assets/google-play-badge.svg" alt="Google Playで手に入れよう"></a>
+          </div>
+        </div>
+        <div>
+          <img src="assets/hero-screenshot.svg" alt="BURN アプリのスクリーンショット" class="hero-screenshot">
+        </div>
       </div>
     </div>
   </header>
 
-  <!-- ヒーロー -->
-  <section class="hero">
-    <div class="container">
-      <h1>BURN</h1>
-      <p class="tagline">UNLEASH THE BEAST</p>
-      <p>近接センサーで自動カウント。<br>腕立て伏せを記録して、毎日の成長を可視化しよう。</p>
-      <a href="#download" class="cta-button">無料ダウンロード</a>
-    </div>
-  </section>
-
-  <!-- 特徴 -->
-  <section id="features" class="features">
-    <div class="container">
-      <h2>特徴</h2>
-      <div class="feature-grid">
-        <div class="feature-card">
-          <div class="feature-icon">�</div>
-          <h3>自動カウント</h3>
-          <p>近接センサーで顔を検知。手でカウントする必要なし。集中してトレーニングに取り組めます。</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">📊</div>
-          <h3>進捗の可視化</h3>
-          <p>週間グラフで成長を確認。日々の努力が一目で分かります。モチベーション維持に最適。</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">�</div>
-          <h3>連続記録</h3>
-          <p>ストリーク機能で毎日の継続をサポート。習慣化を促進して、理想の体を手に入れよう。</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">📈</div>
-          <h3>詳細な記録</h3>
-          <p>回数、タイム、ペース、消費カロリーを自動記録。あなたの成長を数値で実感できます。</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">🎯</div>
-          <h3>シンプル設計</h3>
-          <p>複雑な設定は不要。スマホを置いてスタートボタンを押すだけ。誰でも簡単に使えます。</p>
-        </div>
-        <div class="feature-card">
-          <div class="feature-icon">💪</div>
-          <h3>完全無料</h3>
-          <p>広告なし、課金なし。すべての機能を無料で利用できます。純粋にトレーニングに集中。</p>
+  <main>
+    <section id="features">
+      <div class="container">
+        <h2 class="section-heading">特徴</h2>
+        <p class="section-subtitle">トレーニングの記録からモチベーション維持まで、BURN がサポートします。</p>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <div class="feature-icon">⚡️</div>
+            <h3>ハンズフリー計測</h3>
+            <p>顔を近づけるだけで回数をカウント。フォームに集中できるのでトレーニングが途切れません。</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon">📊</div>
+            <h3>進捗をグラフ化</h3>
+            <p>日・週・月単位のグラフで記録を可視化。継続の成果が目に見えるから続けやすい。</p>
+          </div>
+          <div class="feature-card">
+            <div class="feature-icon">🎯</div>
+            <h3>シンプルな操作</h3>
+            <p>アプリを開いてスタートボタンを押すだけ。誰でも迷わず使える洗練されたUIです。</p>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- 使い方 -->
-  <section id="how-it-works" class="how-it-works">
-    <div class="container">
-      <h2>使い方</h2>
-      <div class="steps">
-        <div class="step">
-          <div class="step-number">1</div>
-          <h3>スマホを床に置く</h3>
-          <p>画面を上向きにして、腕立て伏せをする位置に配置します。</p>
-        </div>
-        <div class="step">
-          <div class="step-number">2</div>
-          <h3>スタートボタン</h3>
-          <p>準備ができたら、大きなオレンジのボタンをタップ。</p>
-        </div>
-        <div class="step">
-          <div class="step-number">3</div>
-          <h3>腕立て開始</h3>
-          <p>顔がスマホに近づくと、自動でカウントされます。</p>
-        </div>
-        <div class="step">
-          <div class="step-number">4</div>
-          <h3>完了</h3>
-          <p>終わったら完了ボタンで記録。成長を実感しよう！</p>
+    <section id="how-it-works">
+      <div class="container">
+        <h2 class="section-heading">使い方</h2>
+        <p class="section-subtitle">4つのステップで今日からスタート。シンプルだから、すぐに習慣にできます。</p>
+        <div class="steps">
+          <div class="step-card">
+            <div class="step-icon">1</div>
+            <h3>スマホをセット</h3>
+            <p>床にスマホを置き、顔が画面に向くようにポジションを調整します。</p>
+          </div>
+          <div class="step-card">
+            <div class="step-icon">2</div>
+            <h3>カウント開始</h3>
+            <p>スタートボタンをタップして腕立て開始。センサーが回数を検知します。</p>
+          </div>
+          <div class="step-card">
+            <div class="step-icon">3</div>
+            <h3>リアルタイム表示</h3>
+            <p>ペースと残り回数をリアルタイムで確認しながら、正しいフォームで継続。</p>
+          </div>
+          <div class="step-card">
+            <div class="step-icon">4</div>
+            <h3>記録＆シェア</h3>
+            <p>ワークアウトを保存して履歴で振り返り。仲間と成果を共有してモチベーションアップ。</p>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- CTA -->
-  <section id="download" class="cta-section">
-    <div class="container">
-      <h2>今すぐ始めよう</h2>
-      <p>無料ダウンロードして、理想の体を手に入れよう。</p>
-      <a href="#" class="cta-button">App Storeからダウンロード</a>
-      <br><br>
-      <a href="#" class="cta-button">Google Playからダウンロード</a>
-    </div>
-  </section>
+    <section id="download">
+      <div class="container">
+        <div class="cta-section">
+          <h2>今日の一回から、未来の成果へ。</h2>
+          <p>BURN で腕立ての習慣化をサポート。今すぐダウンロードして、成長を始めよう。</p>
+          <div class="store-buttons">
+            <a href="#"><img src="assets/app-store-badge.svg" alt="App Storeでダウンロード"></a>
+            <a href="#"><img src="assets/google-play-badge.svg" alt="Google Playで手に入れよう"></a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
 
-  <!-- フッター -->
   <footer>
     <div class="container">
       <div class="footer-links">


### PR DESCRIPTION
## Summary
- restyle the landing page with a minimal dark navy and orange palette
- focus hero content around the app icon, concise copy, screenshot, and store badges
- trim sections to a three-item features grid, four-step guide, and simple CTA with new SVG assets

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcb07b1188832c9edf69a2dad30a4a