### PR TITLE
Fix OGP image meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
   <meta property="og:url" content="https://kinariku.github.io/burn-site/">
   <meta property="og:title" content="BURN - 腕立てトラッキングアプリ">
   <meta property="og:description" content="近接センサーで自動カウント。腕立て伏せを記録して、毎日の成長を可視化しよう。">
-  <meta property="og:image" content="https://github.com/kinariku/burn-site/raw/main/assets/burn_ogp.png">
+  <meta property="og:image" content="https://kinariku.github.io/burn-site/assets/burn_ogp.png">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://kinariku.github.io/burn-site/">
   <meta property="twitter:title" content="BURN - 腕立てトラッキングアプリ">
   <meta property="twitter:description" content="近接センサーで自動カウント。腕立て伏せを記録して、毎日の成長を可視化しよう。">
-  <meta property="twitter:image" content="https://github.com/kinariku/burn-site/raw/main/assets/burn_ogp.png">
+  <meta property="twitter:image" content="https://kinariku.github.io/burn-site/assets/burn_ogp.png">
   <style>
     :root {
       --color-background: #0f172a;


### PR DESCRIPTION
## Summary
- update the Open Graph and Twitter image URLs to the hosted GitHub Pages asset so social previews work

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68dd11a1ba90832cb8d771a6a86c9ff8